### PR TITLE
Added Maghead, marked LazyRecord as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,8 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Doctrine Extensions](https://github.com/Atlantic18/DoctrineExtensions) - A collection of Doctrine behavioural extensions.
 * [Doctrine](https://www.doctrine-project.org/) - A comprehensive DBAL and ORM.
 * [Eloquent](https://github.com/illuminate/database) - A simple ORM (L5).
-* [LazyRecord](https://github.com/corneltek/LazyRecord) - A fast ORM designed for simplicity, extendability and performance.
+* [Maghead](https://github.com/maghead/maghead) - Lightweight, fast ORM for PHP7. (Originally LazyRecord)
+* [LazyRecord](https://github.com/corneltek/LazyRecord) - (No longer maintained) A fast ORM designed for simplicity, extendability and performance.
 * [Pomm](https://github.com/chanmix51/Pomm) - An Object Model Manager for PostgreSQL.
 * [Propel](http://propelorm.org/) - A fast ORM, migration library and query builder.
 * [ProxyManager](https://github.com/Ocramius/ProxyManager) - A set of utilities to generate proxy objects for data mappers.


### PR DESCRIPTION
LazyRecord repo description says it is a historical repo, and refers to Maghead.